### PR TITLE
set jvmToolchain version to 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,11 @@ repositories {
     mavenCentral()
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 kotlin {
     jvmToolchain(11)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 gradlePlugin {


### PR DESCRIPTION
All lavalink repositories use java 11, but this one alone uses java 17.

jitpack build of youtube-source fails in java 11